### PR TITLE
Module name fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "author": "Sergio Xalambrí",
   "main": "dist/index.js",
-  "module": "dist/a.esm.js",
+  "module": "dist/use-mutation.esm.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist",


### PR DESCRIPTION
This fixes an issue where some bundlers (Vite in my case) weren't able to find ESM bundle of this package due to the wrong module name in package.json.