### PR TITLE
Options interface export

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import useSafeCallback from 'use-safe-callback';
 
 type rollbackFn = () => void;
 
-interface Options<Input, Data, Error> {
+export interface Options<Input, Data, Error> {
   /**
    * A function to be executed before the mutation runs.
    *


### PR DESCRIPTION
Added `export` to the `Options` interface.
The change is needed to support use cases in which wrapper hooks might need to type check parameters passed to `useMutation` hook. 