### PR TITLE
feat: add MutationResult type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -81,7 +81,7 @@ function useGetLatest<Value>(value: Value): () => Value {
 
 export type Reset = () => void;
 
-export type MutationResult<Input = any, Data = any, Error = any> = [(input: Input) => Promise<Data | undefined>, { status: Status, data?: Data, error?: Error, reset: Reset }];
+export type MutationResult<Input, Data, Error> = [(input: Input) => Promise<Data | undefined>, { status: Status, data?: Data, error?: Error, reset: Reset }];
 
 /**
  * Hook to run async function which cause a side-effect, specially useful to
@@ -192,5 +192,5 @@ export default function useMutation<Input = any, Data = any, Error = any>(
 
   if (useErrorBoundary && error) throw error;
 
-  return ([mutate, { status, data, error, reset }]);
+  return [mutate, { status, data, error, reset }];
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -64,7 +64,7 @@ export interface Options<Input, Data, Error> {
   useErrorBoundary?: boolean;
 }
 
-type Status = 'idle' | 'running' | 'success' | 'failure';
+export type Status = 'idle' | 'running' | 'success' | 'failure';
 
 function noop() {}
 
@@ -78,6 +78,10 @@ function useGetLatest<Value>(value: Value): () => Value {
   ref.current = value;
   return useCallback(() => ref.current, []);
 }
+
+export type Reset = () => void;
+
+export type MutationResult<Input = any, Data = any, Error = any> = [(input: Input) => Promise<Data | undefined>, { status: Status, data?: Data, error?: Error, reset: Reset }];
 
 /**
  * Hook to run async function which cause a side-effect, specially useful to
@@ -93,7 +97,7 @@ export default function useMutation<Input = any, Data = any, Error = any>(
     throwOnFailure = false,
     useErrorBoundary = false,
   }: Options<Input, Data, Error> = {}
-) {
+): MutationResult<Input, Data, Error> {
   type State = { status: Status; data?: Data; error?: Error };
 
   type Action =
@@ -188,13 +192,5 @@ export default function useMutation<Input = any, Data = any, Error = any>(
 
   if (useErrorBoundary && error) throw error;
 
-  return ([mutate, { status, data, error, reset }] as unknown) as [
-    typeof mutate,
-    {
-      status: Status;
-      data?: Data;
-      error?: Error;
-      reset: typeof reset;
-    }
-  ];
+  return ([mutate, { status, data, error, reset }]);
 }


### PR DESCRIPTION
This type can be used for typing functions with TS, like this: 

```
export function useCreateProduct(): MutationResult<Input, Data> {}
```

Also removes casting at the end of the hook.