### PR TITLE
Docs fix - "Use with SWR" onFailure callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ function useCreateComment() {
       return () => mutate('comment-list', oldData, false); // rollback if it failed
     },
 
-    onFailure({ status, rollback }) {
-      if (status === 'failure' && rollback) rollback();
+    onFailure({ rollback }) {
+      if (rollback) rollback();
     },
   });
 }


### PR DESCRIPTION
There is no `status` info in the onFailure params. Also there is no need to check the status because we are already in failure handler.